### PR TITLE
Split Rune Carver runes into auto-level features

### DIFF
--- a/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
+++ b/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
@@ -136,6 +136,7 @@
         <text>   This rune emulates the deceptive magic used by some cloud giants. While wearing or carrying an object inscribed with this rune, you have advantage on Dexterity (Sleight of Hand) checks and Charisma (Deception) checks.</text>
         <text>   In addition, when you or a creature you can see within 30 feet of you is hit by an attack roll, you can use your reaction to invoke the rune and choose a different creature within 30 feet of you, other than the attacker. The chosen creature becomes the target of the attack, using the same roll. This magic can transfer the attack's effects regardless of the attack's range. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text/>
+        <text>3rd-level Rune Knight feature</text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
@@ -145,6 +146,7 @@
         <text>   This rune's magic channels the masterful craftsmanship of great smiths. While wearing or carrying an object inscribed with this rune, your proficiency bonus is doubled for any ability check you make that uses your proficiency with a tool.</text>
         <text>   In addition, when you hit a creature with an attack using a weapon, you can invoke the rune to summon fiery shackles: the target takes an extra 2d6 fire damage, and it must succeed on a Strength saving throw or be restrained for 1 minute. While restrained by the shackles, the target takes 2d6 fire damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, banishing the shackles on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text/>
+        <text>3rd-level Rune Knight feature</text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
@@ -154,6 +156,7 @@
         <text>   This rune's magic evokes the might of those who survive in the wintry wilderness, such as frost giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Animal Handling) checks and Charisma (Intimidation) checks.</text>
         <text>   In addition, you can invoke the rune as a bonus action to increase your sturdiness. For 10 minutes, you gain a +2 bonus to all ability checks and saving throws that use Strength or Constitution. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text/>
+        <text>3rd-level Rune Knight feature</text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
@@ -162,6 +165,7 @@
         <name>Rune Knight: Stone Rune</name>
         <text>   This rune's magic channels the judiciousness associated with stone giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Insight) checks, and you have darkvision out to a range of 120 feet.</text>
         <text>   In addition, when a creature you can see ends its turn within 30 feet of you, you can use your reaction to invoke the rune and force the creature to make a Wisdom saving throw. Unless the save succeeds, the creature is charmed by you for 1 minute. While charmed in this way, the creature has a speed of 0 and is incapacitated, descending into a dreamy stupor. The creature repeats the saving throw at the end of each of its turns, ending the effect on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text>3rd-level Rune Knight feature</text>
         <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
         </feature>
@@ -208,6 +212,7 @@
         <text>   This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being poisoned, and you have resistance against poison damage.</text>
         <text>   In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text/>
+        <text>7th-level Rune Knight feature</text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
@@ -217,6 +222,7 @@
           <text>   Using this rune, you can glimpse the future like a storm giant seer. While wearing or carrying an object inscribed with this rune, you have advantage on Intelligence (Arcana) checks, and you can't be surprised as long as you aren't incapacitated.</text>
           <text>   In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're incapacitated. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
           <text/>
+          <text>7th-level Rune Knight feature</text>
           <text>Source: Tasha's Cauldron of Everything p. 44</text>
         </feature>
     </autolevel>

--- a/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
+++ b/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
@@ -126,24 +126,42 @@
         <text>10th | 4</text>
         <text>15th | 5</text>
         <text>The following runes are available to you when you learn a rune. If a rune has a level requirement, you must be at least that level in this class to learn the rune. If a rune requires a saving throw, your Rune Magic save DC equals 8 + your proficiency bonus + your Constitution modifier.</text>
+        <text/>
+        <text>Source: Tasha's Cauldron of Everything p. 44</text>
+      </feature>
+    </autolevel>
+    <autolevel level="3">
+      <feature optional="YES">
         <name>Rune Knight: Cloud Rune</name>
         <text>   This rune emulates the deceptive magic used by some cloud giants. While wearing or carrying an object inscribed with this rune, you have advantage on Dexterity (Sleight of Hand) checks and Charisma (Deception) checks.</text>
         <text>   In addition, when you or a creature you can see within 30 feet of you is hit by an attack roll, you can use your reaction to invoke the rune and choose a different creature within 30 feet of you, other than the attacker. The chosen creature becomes the target of the attack, using the same roll. This magic can transfer the attack's effects regardless of the attack's range. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text/>
+        <text>Source: Tasha's Cauldron of Everything p. 44</text>
+      </feature>
+    </autolevel>
+    <autolevel level="3">
+      <feature optional="YES">
         <name>Rune Knight: Fire Rune</name>
         <text>   This rune's magic channels the masterful craftsmanship of great smiths. While wearing or carrying an object inscribed with this rune, your proficiency bonus is doubled for any ability check you make that uses your proficiency with a tool.</text>
         <text>   In addition, when you hit a creature with an attack using a weapon, you can invoke the rune to summon fiery shackles: the target takes an extra 2d6 fire damage, and it must succeed on a Strength saving throw or be restrained for 1 minute. While restrained by the shackles, the target takes 2d6 fire damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, banishing the shackles on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text/>
+        <text>Source: Tasha's Cauldron of Everything p. 44</text>
+      </feature>
+    </autolevel>
+    <autolevel level="3">
+      <feature optional="YES">
         <name>Rune Knight: Frost Rune</name>
         <text>   This rune's magic evokes the might of those who survive in the wintry wilderness, such as frost giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Animal Handling) checks and Charisma (Intimidation) checks.</text>
         <text>   In addition, you can invoke the rune as a bonus action to increase your sturdiness. For 10 minutes, you gain a +2 bonus to all ability checks and saving throws that use Strength or Constitution. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text/>
+        <text>Source: Tasha's Cauldron of Everything p. 44</text>
+      </feature>
+    </autolevel>
+    <autolevel level="3">
+      <feature optional="YES">
         <name>Rune Knight: Stone Rune</name>
         <text>   This rune's magic channels the judiciousness associated with stone giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Insight) checks, and you have darkvision out to a range of 120 feet.</text>
         <text>   In addition, when a creature you can see ends its turn within 30 feet of you, you can use your reaction to invoke the rune and force the creature to make a Wisdom saving throw. Unless the save succeeds, the creature is charmed by you for 1 minute. While charmed in this way, the creature has a speed of 0 and is incapacitated, descending into a dreamy stupor. The creature repeats the saving throw at the end of each of its turns, ending the effect on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <name>Rune Knight: Hill Rune (7th Level or Higher)</name>
-        <text>   This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being poisoned, and you have resistance against poison damage.</text>
-        <text>   In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <name>Rune Knight: Storm Rune (7th Level or Higher)</name>
-        <text>   Using this rune, you can glimpse the future like a storm giant seer. While wearing or carrying an object inscribed with this rune, you have advantage on Intelligence (Arcana) checks, and you can't be surprised as long as you aren't incapacitated.</text>
-        <text>   In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're incapacitated. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
         </feature>
@@ -184,6 +202,24 @@
         <text>Source: Tasha's Cauldron of Everything p. 42</text>
         </feature>
       </autolevel>
+    <autolevel level="7">
+      <feature optional="YES">
+        <name>Rune Knight: Hill Rune</name>
+        <text>   This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being poisoned, and you have resistance against poison damage.</text>
+        <text>   In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text/>
+        <text>Source: Tasha's Cauldron of Everything p. 44</text>
+      </feature>
+    </autolevel>
+    <autolevel level="7">
+        <feature optional="YES">
+          <name>Rune Knight: Storm Rune</name>
+          <text>   Using this rune, you can glimpse the future like a storm giant seer. While wearing or carrying an object inscribed with this rune, you have advantage on Intelligence (Arcana) checks, and you can't be surprised as long as you aren't incapacitated.</text>
+          <text>   In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're incapacitated. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+          <text/>
+          <text>Source: Tasha's Cauldron of Everything p. 44</text>
+        </feature>
+    </autolevel>
     <autolevel level="7">
         <feature optional="YES">
           <name>Rune Knight: Runic Shield</name>

--- a/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
+++ b/FightClub5eXML/Sources/TashasCauldronOfEverything/class-fighter-tce.xml
@@ -126,46 +126,46 @@
         <text>10th | 4</text>
         <text>15th | 5</text>
         <text>The following runes are available to you when you learn a rune. If a rune has a level requirement, you must be at least that level in this class to learn the rune. If a rune requires a saving throw, your Rune Magic save DC equals 8 + your proficiency bonus + your Constitution modifier.</text>
-        <text/>
+        <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
     <autolevel level="3">
       <feature optional="YES">
-        <name>Rune Knight: Cloud Rune</name>
-        <text>   This rune emulates the deceptive magic used by some cloud giants. While wearing or carrying an object inscribed with this rune, you have advantage on Dexterity (Sleight of Hand) checks and Charisma (Deception) checks.</text>
-        <text>   In addition, when you or a creature you can see within 30 feet of you is hit by an attack roll, you can use your reaction to invoke the rune and choose a different creature within 30 feet of you, other than the attacker. The chosen creature becomes the target of the attack, using the same roll. This magic can transfer the attack's effects regardless of the attack's range. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <text/>
+          <name>Rune Knight: Cloud Rune</name>
         <text>3rd-level Rune Knight feature</text>
+        <text>This rune emulates the deceptive magic used by some cloud giants. While wearing or carrying an object inscribed with this rune, you have advantage on Dexterity (Sleight of Hand) checks and Charisma (Deception) checks.</text>
+        <text>In addition, when you or a creature you can see within 30 feet of you is hit by an attack roll, you can use your reaction to invoke the rune and choose a different creature within 30 feet of you, other than the attacker. The chosen creature becomes the target of the attack, using the same roll. This magic can transfer the attack's effects regardless of the attack's range. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
     <autolevel level="3">
       <feature optional="YES">
-        <name>Rune Knight: Fire Rune</name>
-        <text>   This rune's magic channels the masterful craftsmanship of great smiths. While wearing or carrying an object inscribed with this rune, your proficiency bonus is doubled for any ability check you make that uses your proficiency with a tool.</text>
-        <text>   In addition, when you hit a creature with an attack using a weapon, you can invoke the rune to summon fiery shackles: the target takes an extra 2d6 fire damage, and it must succeed on a Strength saving throw or be restrained for 1 minute. While restrained by the shackles, the target takes 2d6 fire damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, banishing the shackles on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <text/>
+          <name>Rune Knight: Fire Rune</name>
         <text>3rd-level Rune Knight feature</text>
+        <text>This rune's magic channels the masterful craftsmanship of great smiths. While wearing or carrying an object inscribed with this rune, your proficiency bonus is doubled for any ability check you make that uses your proficiency with a tool.</text>
+        <text>In addition, when you hit a creature with an attack using a weapon, you can invoke the rune to summon fiery shackles: the target takes an extra 2d6 fire damage, and it must succeed on a Strength saving throw or be restrained for 1 minute. While restrained by the shackles, the target takes 2d6 fire damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, banishing the shackles on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
     <autolevel level="3">
       <feature optional="YES">
-        <name>Rune Knight: Frost Rune</name>
-        <text>   This rune's magic evokes the might of those who survive in the wintry wilderness, such as frost giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Animal Handling) checks and Charisma (Intimidation) checks.</text>
-        <text>   In addition, you can invoke the rune as a bonus action to increase your sturdiness. For 10 minutes, you gain a +2 bonus to all ability checks and saving throws that use Strength or Constitution. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <text/>
+          <name>Rune Knight: Frost Rune</name>
         <text>3rd-level Rune Knight feature</text>
+        <text>This rune's magic evokes the might of those who survive in the wintry wilderness, such as frost giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Animal Handling) checks and Charisma (Intimidation) checks.</text>
+        <text>In addition, you can invoke the rune as a bonus action to increase your sturdiness. For 10 minutes, you gain a +2 bonus to all ability checks and saving throws that use Strength or Constitution. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
     <autolevel level="3">
       <feature optional="YES">
-        <name>Rune Knight: Stone Rune</name>
-        <text>   This rune's magic channels the judiciousness associated with stone giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Insight) checks, and you have darkvision out to a range of 120 feet.</text>
-        <text>   In addition, when a creature you can see ends its turn within 30 feet of you, you can use your reaction to invoke the rune and force the creature to make a Wisdom saving throw. Unless the save succeeds, the creature is charmed by you for 1 minute. While charmed in this way, the creature has a speed of 0 and is incapacitated, descending into a dreamy stupor. The creature repeats the saving throw at the end of each of its turns, ending the effect on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+          <name>Rune Knight: Stone Rune</name>
         <text>3rd-level Rune Knight feature</text>
+        <text>This rune's magic channels the judiciousness associated with stone giants. While wearing or carrying an object inscribed with this rune, you have advantage on Wisdom (Insight) checks, and you have darkvision out to a range of 120 feet.</text>
+        <text>In addition, when a creature you can see ends its turn within 30 feet of you, you can use your reaction to invoke the rune and force the creature to make a Wisdom saving throw. Unless the save succeeds, the creature is charmed by you for 1 minute. While charmed in this way, the creature has a speed of 0 and is incapacitated, descending into a dreamy stupor. The creature repeats the saving throw at the end of each of its turns, ending the effect on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
         <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
         </feature>
@@ -208,21 +208,21 @@
       </autolevel>
     <autolevel level="7">
       <feature optional="YES">
-        <name>Rune Knight: Hill Rune</name>
-        <text>   This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being poisoned, and you have resistance against poison damage.</text>
-        <text>   In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-        <text/>
+          <name>Rune Knight: Hill Rune</name>
         <text>7th-level Rune Knight feature</text>
+        <text>This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being poisoned, and you have resistance against poison damage.</text>
+        <text>In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+        <text></text>
         <text>Source: Tasha's Cauldron of Everything p. 44</text>
       </feature>
     </autolevel>
     <autolevel level="7">
         <feature optional="YES">
-          <name>Rune Knight: Storm Rune</name>
-          <text>   Using this rune, you can glimpse the future like a storm giant seer. While wearing or carrying an object inscribed with this rune, you have advantage on Intelligence (Arcana) checks, and you can't be surprised as long as you aren't incapacitated.</text>
-          <text>   In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're incapacitated. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
-          <text/>
+            <name>Rune Knight: Storm Rune</name>
           <text>7th-level Rune Knight feature</text>
+          <text>Using this rune, you can glimpse the future like a storm giant seer. While wearing or carrying an object inscribed with this rune, you have advantage on Intelligence (Arcana) checks, and you can't be surprised as long as you aren't incapacitated.</text>
+          <text>In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're incapacitated. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest.</text>
+          <text></text>
           <text>Source: Tasha's Cauldron of Everything p. 44</text>
         </feature>
     </autolevel>


### PR DESCRIPTION
Splits the Rune Knight: Rune Carver feature of the Fighter Martial Archetype: Rune Knight into separate features that are auto-levelled.

Fixes #120 