### PR TITLE
Separate Cleric Visions of the Past Feature

### DIFF
--- a/FightClub5eXML/Sources/PlayersHandbook/class-cleric-phb.xml
+++ b/FightClub5eXML/Sources/PlayersHandbook/class-cleric-phb.xml
@@ -674,9 +674,21 @@
           <name>Knowledge Domain: Visions of the Past</name>
         <text>Starting at 17th level, you can call up visions of the past that relate to an object you hold or your immediate surroundings. You spend at least 1 minute in meditation and prayer, then receive dreamlike, shadowy glimpses of recent events. You can meditate in this way for a number of minutes equal to your Wisdom score and must maintain concentration during that time, as if you were casting a spell.</text>
         <text>Once you use this feature, you can't use it again until you finish a short or long rest.</text>
-        <name>Knowledge Domain: Object Reading</name>
+        <text></text>
+        <text>Source: Player's Handbook p. 59</text>
+        </feature>
+      </autolevel>
+    <autolevel level="17">
+        <feature optional="YES">
+          <name>Knowledge Domain: Object Reading</name>
         <text>   Holding an object as you meditate, you can see visions of the object's previous owner. After meditating for 1 minute, you learn how the owner acquired and lost the object, as well as the most recent significant event involving the object and that owner. If the object was owned by another creature in the recent past (within a number of days equal to your Wisdom score), you can spend 1 additional minute for each owner to learn the same information about that creature.</text>
-        <name>Knowledge Domain: Area Reading</name>
+        <text></text>
+        <text>Source: Player's Handbook p. 59</text>
+        </feature>
+      </autolevel>
+    <autolevel level="17">
+        <feature optional="YES">
+          <name>Knowledge Domain: Area Reading</name>
         <text>   As you meditate, you see visions of recent events in your immediate vicinity (a room, street, tunnel, clearing, or the like, up to a 50-foot cube), going back a number of days equal to your Wisdom score. For each minute you meditate, you learn about one significant event, beginning with the most recent. Significant events typically involve powerful emotions, such as battles and betrayals, marriages and murders, births and funerals. However, they might also include more mundane events that are nevertheless important in your current situation.</text>
         <text></text>
         <text>Source: Player's Handbook p. 59</text>


### PR DESCRIPTION
Separate Knowledge Domain: Visions of the Past Cleric class feature into distinct class features.

Fixes #125 