### PR TITLE
Get Travis CI working for PRs again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
       - xmlstarlet
       - xsltproc
 before_install:
-    - rvm install 2.3.8
+    - rvm install 2.4.5
     - gem install dropbox-deployment
 script:
     - xmlstarlet val -e FightClub5eXML/Sources/*.xml


### PR DESCRIPTION
This PR updates `.travis.yml` to use newer version of Ruby (2.4.5) in order to get Travis CI working again for PRs. It at least partially addresses issue #161.