### PR TITLE
Add github actions workflow to compile collections and create releases

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,42 @@
+name: Compile all collections into compendiums
+on: 
+  push:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  compile_collections:
+    name: Compile collections
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install xsltproc
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: xsltproc
+          version: 1.0
+
+      - name: Compile collections into compendiums
+        run: |
+          cd Collections
+          for f in *.xml; do
+            xsltproc -o "../Compendiums/$f" "../Utilities/merge.xslt" "$f"
+          done
+          cd ..
+
+      - name: Zip up compendiums
+        run: zip -r compendiums.zip Compendiums/*.xml
+
+      - name: Store resulting compendiums as artifact
+        uses: actions/upload-artifact@v3
+        with: 
+          name: compendiums
+          path: compendiums.zip
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Compendiums/*


### PR DESCRIPTION
This pull request essentially enables Github Actions for this repository to automatically compile collections into compendiums and make those easier to download both for users and maintainers of this repo. 

The workflow automatically compiles and zips up compendiums on pushes and pull requests, making testing of new PRs easier. 

Additionally, when a tag is created, a new release will be created with all compiled compendiums added to the release, vastly simplifying usability. 

To make the release step work properly, you will need to configure the repository Github Actions workflow permissions. To do so:

1. Click "Settings" on the repository.
2. Under "Code and automation", click Actions -> General
3. Scroll down to "Workflow permissions" and select the "Read and write permissions" radio button.
4. Click "Save".